### PR TITLE
added a pretty printer for Kernel.Expr.Internal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.stack-work

--- a/leantc.cabal
+++ b/leantc.cabal
@@ -22,6 +22,7 @@ library
                      , transformers
                      , text
                      , parsec
+                     , pretty
   default-language:    Haskell2010
   ghc-options:         -O3 -threaded
 


### PR DESCRIPTION
Not sure if you are interested in pull requests......................

I wrote a pretty printer for ther Expression type in Kernel.Expr.Internal

It behaves exactly like the string based one you had before, but it should be easier to modify.

